### PR TITLE
Adapt Tizen Dockerfiles

### DIFF
--- a/integrations/docker/images/stage-2/chip-build-tizen/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-tizen/Dockerfile
@@ -3,24 +3,12 @@ FROM ghcr.io/project-chip/chip-build:${VERSION}
 LABEL org.opencontainers.image.source https://github.com/project-chip/connectedhomeip
 
 # ------------------------------------------------------------------------------
-# Add group/user for tizen
-ARG USER_NAME=tizen
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-ENV USER_HOME /home/$USER_NAME
-
-RUN set -x \
-    && groupadd -g $USER_GID $USER_NAME \
-    && useradd -m $USER_NAME -s /bin/bash -u $USER_UID -g $USER_GID -G sudo -l \
-    && : # last line
-
-# ------------------------------------------------------------------------------
 # Install dependencies
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
     cpio \
-    libncurses5 \
+    libncurses6 \
     obs-build \
     openjdk-8-jre-headless \
     wget \
@@ -39,7 +27,7 @@ COPY tizen-sdk-installer $TIZEN_SDK_ROOT/files/installer
 RUN set -x \
     && bash $TIZEN_SDK_ROOT/files/installer/install.sh \
     --tizen-sdk-path $TIZEN_SDK_ROOT \
-    --tizen-sdk-data-path $USER_HOME/tizen-sdk-data \
+    --tizen-sdk-data-path /home/ubuntu/tizen-sdk-data \
     --tizen-version $TIZEN_VERSION  \
     --override-secret-tool \
     && : # last line
@@ -52,5 +40,5 @@ ENV PATH="$TIZEN_SDK_TOOLCHAIN/bin:$TIZEN_SDK_ROOT/tools/ide/bin:$TIZEN_SDK_ROOT
 
 # ------------------------------------------------------------------------------
 # Switch to the non-root user
-USER $USER_NAME
-WORKDIR $USER_HOME
+USER ubuntu
+WORKDIR /home/ubuntu

--- a/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
@@ -19,7 +19,9 @@ RUN set -x \
     genisoimage \
     libgmp-dev \
     libmpc-dev \
+    patch \
     qemu-system-arm \
+    xz-utils \
     # Cleanup
     && apt-get clean \
     && rm -rf /var/lib/apt/lists \
@@ -58,7 +60,7 @@ RUN set -x \
     && ./scripts/config -e OVERLAY_FS -e ISO9660_FS \
     && ./scripts/config -e SECURITY_SMACK_PERMISSIVE_MODE \
     && make olddefconfig \
-    && make zImage \
+    && make -j$(nproc) zImage \
     && mv arch/arm/boot/zImage $TIZEN_IOT_QEMU_KERNEL \
     # Cleanup
     && rm -rf /tmp/workdir \
@@ -194,5 +196,5 @@ RUN set -x \
 
 # ------------------------------------------------------------------------------
 # Switch back to the non-root user
-USER $USER_NAME
-WORKDIR $USER_HOME
+USER ubuntu
+WORKDIR /home/ubuntu


### PR DESCRIPTION
Few changes needed to make Tizen work:
- apt install various libraries
- build kernel with $(nproc) threads
- don't create new non-root user, because the 24.04 dockerfile already has one called `ubuntu`

